### PR TITLE
Fix for #10 Broken SIMD L2Sqr distance computation

### DIFF
--- a/algorithms/utils/NSGDist.h
+++ b/algorithms/utils/NSGDist.h
@@ -46,28 +46,25 @@ class DistanceL2 : public Distance {
     __m256 sum;
     __m256 l0, l1;
     __m256 r0, r1;
-    unsigned D = (size + 7) & ~7U;
-    unsigned DR = D % 16;
-    unsigned DD = D - DR;
+    size_t qty16 = size >> 4;
+    size_t aligned_size = qty16 << 4;
     const float *l = a;
     const float *r = b;
-    const float *e_l = l + DD;
-    const float *e_r = r + DD;
+
     float unpack[8] __attribute__((aligned(32))) = {0, 0, 0, 0, 0, 0, 0, 0};
-
     sum = _mm256_loadu_ps(unpack);
-    if (DR) {
-      AVX_L2SQR(e_l, e_r, sum, l0, r0);
-    }
 
-    for (unsigned i = 0; i < DD; i += 16, l += 16, r += 16) {
+    for (unsigned i = 0; i < aligned_size; i += 16, l += 16, r += 16) {
       AVX_L2SQR(l, r, sum, l0, r0);
       AVX_L2SQR(l + 8, r + 8, sum, l1, r1);
     }
     _mm256_storeu_ps(unpack, sum);
-    result = unpack[0] + unpack[1] + unpack[2] + unpack[3] + unpack[4] +
-             unpack[5] + unpack[6] + unpack[7];
-
+    result = unpack[0] + unpack[1] + unpack[2] + unpack[3] + unpack[4] + unpack[5] + unpack[6] + unpack[7];
+    for (unsigned i = aligned_size; i < size; ++i, ++l, ++r) {
+      float diff = *l - *r;
+      result += diff * diff;
+    }
+    
     /*
 #else
 #ifdef __SSE2__


### PR DESCRIPTION
See issue #10 for a description.
Fix: Process the end of a vector without SIMD.