### PR TITLE
Remove deps

### DIFF
--- a/algorithms/utils/BUILD
+++ b/algorithms/utils/BUILD
@@ -36,33 +36,6 @@ cc_library(
     ],
 )
 
-# cc_library(
-#     name = "beamSearch",
-#     hdrs = ["beamSearch.h"],
-#     deps = [
-#         "@parlaylib//parlay:io",
-#         "@parlaylib//parlay:parallel",
-#         "@parlaylib//parlay:primitives",
-#         "@parlaylib//parlay:random",
-#         ":indexTools",
-#         ":types",
-#     ],
-# )
-
-# cc_library(
-#     name = "check_nn_recall",
-#     hdrs = ["check_nn_recall.h"],
-#     deps = [
-#         "@parlaylib//parlay:parallel",
-#         "@parlaylib//parlay:primitives",
-#         ":beamSearch",
-#         ":csvfile",
-#         ":parse_results",
-#         ":stats",
-#         ":types",
-#     ],
-# )
-
 cc_library(
     name = "euclidean_point",
     hdrs = ["euclidian_point.h"],
@@ -70,7 +43,6 @@ cc_library(
         "@parlaylib//parlay:parallel",
         "@parlaylib//parlay:primitives",
         "@parlaylib//parlay/internal:file_map",
-        "//algorithms/bench:parse_command_line",
         ":parse_results",
         ":NSGDist",
     ],
@@ -83,7 +55,6 @@ cc_library(
         "@parlaylib//parlay:parallel",
         "@parlaylib//parlay:primitives",
         "@parlaylib//parlay/internal:file_map",
-        "//algorithms/bench:parse_command_line",
         ":parse_results",
         ":NSGDist",
     ],
@@ -96,7 +67,6 @@ cc_library(
         "@parlaylib//parlay:parallel",
         "@parlaylib//parlay:primitives",
         "@parlaylib//parlay/internal:file_map",
-        "//algorithms/bench:parse_command_line",
         ":NSGDist",
         ":types",
     ],
@@ -109,7 +79,6 @@ cc_library(
         "@parlaylib//parlay:parallel",
         "@parlaylib//parlay:primitives",
         "@parlaylib//parlay/internal:file_map",
-        "//algorithms/bench:parse_command_line",
     ],
 )
 
@@ -151,7 +120,6 @@ cc_library(
         "@parlaylib//parlay:parallel",
         "@parlaylib//parlay:primitives",
         "@parlaylib//parlay/internal:file_map",
-        "//algorithms/bench:parse_command_line",
         ":types",
     ],
 )

--- a/algorithms/utils/euclidian_point.h
+++ b/algorithms/utils/euclidian_point.h
@@ -29,7 +29,6 @@
 #include "parlay/parallel.h"
 #include "parlay/primitives.h"
 #include "parlay/internal/file_map.h"
-#include "../bench/parse_command_line.h"
 #include "NSGDist.h"
 
 #include "types.h"

--- a/algorithms/utils/graph.h
+++ b/algorithms/utils/graph.h
@@ -34,7 +34,6 @@
 #include "parlay/primitives.h"
 #include "parlay/internal/file_map.h"
 
-#include "../bench/parse_command_line.h"
 #include "types.h"
 
 namespace parlayANN {

--- a/algorithms/utils/jl_point.h
+++ b/algorithms/utils/jl_point.h
@@ -7,7 +7,6 @@
 #include "parlay/parallel.h"
 #include "parlay/primitives.h"
 #include "parlay/internal/file_map.h"
-#include "../bench/parse_command_line.h"
 #include "NSGDist.h"
 #include "types.h"
 

--- a/algorithms/utils/mips_point.h
+++ b/algorithms/utils/mips_point.h
@@ -30,7 +30,6 @@
 #include "parlay/parallel.h"
 #include "parlay/primitives.h"
 #include "parlay/internal/file_map.h"
-#include "../bench/parse_command_line.h"
 #include "NSGDist.h"
 #include "types.h"
 

--- a/algorithms/utils/mmap.h
+++ b/algorithms/utils/mmap.h
@@ -7,7 +7,6 @@
 #include "parlay/parallel.h"
 #include "parlay/primitives.h"
 #include "parlay/internal/file_map.h"
-#include "../bench/parse_command_line.h"
 
 namespace parlayANN {
 

--- a/algorithms/utils/point_range.h
+++ b/algorithms/utils/point_range.h
@@ -29,7 +29,6 @@
 #include "parlay/parallel.h"
 #include "parlay/primitives.h"
 #include "parlay/internal/file_map.h"
-#include "../bench/parse_command_line.h"
 #include "types.h"
 
 #include <fcntl.h>

--- a/algorithms/utils/types.h
+++ b/algorithms/utils/types.h
@@ -27,6 +27,7 @@
 #define TYPES
 
 #include <algorithm>
+#include <fstream>
 
 #include "parlay/parallel.h"
 #include "parlay/primitives.h"


### PR DESCRIPTION
Remove unnecessary dependencies on parse_command_line utility.

Also, removes commented out BUILD targets