### PR TITLE
Reduce memory footprint of Mips_Quantized_Point during construction

### DIFF
--- a/algorithms/utils/mips_point.h
+++ b/algorithms/utils/mips_point.h
@@ -449,7 +449,7 @@ struct Quantized_Mips_Point{
     });
     if (trim) {
       double cutoff = .0001;
-      size_t min_rank = (cutoff * n);
+      size_t min_rank = cutoff * n;
       size_t max_rank = (1.0 - cutoff) * (n - 1);
 
       min_val = parlay::kth_smallest_copy(min_per_point, min_rank);


### PR DESCRIPTION
Eliminate 3x memory blowup in parlayANN's scalar MIPS quantization code, which computes 0.0001 quantiles by sorting. The memory blowup is due to 1) copying all of the coordinates, 2) parlay::sort_inplace is not in-place (https://github.com/cmuparlay/parlaylib/issues/80).
This change will result in sligthly different results due to computing quantiles on the min and max coordinates per point (instead of all coordinates), but should be fairly close to the old results.