### PR TITLE
mark two functions inline --> fix duplicate symbol error in linker

### DIFF
--- a/algorithms/utils/mmap.h
+++ b/algorithms/utils/mmap.h
@@ -11,7 +11,7 @@
 namespace parlayANN {
 
 // returns a pointer and a length
-std::pair<char*, size_t> mmapStringFromFile(const char* filename) {
+inline std::pair<char*, size_t> mmapStringFromFile(const char* filename) {
   struct stat sb;
   int fd = open(filename, O_RDONLY);
   if (fd == -1) {

--- a/algorithms/utils/stats.h
+++ b/algorithms/utils/stats.h
@@ -44,7 +44,7 @@ namespace parlayANN {
 //   return std::make_pair(avg_deg, maxDegree);
 // }
 
-std::pair<double, int> graph_stats_(Graph<unsigned int> &G) {
+inline std::pair<double, int> graph_stats_(Graph<unsigned int> &G) {
   auto od = parlay::delayed_seq<size_t>(
       G.size(), [&](size_t i) { return G[i].size(); });
   size_t j = parlay::max_element(od) - od.begin();


### PR DESCRIPTION
...when including beamSearch.h more than once